### PR TITLE
将pool线程池修改为静态

### DIFF
--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
@@ -5,7 +5,9 @@ import java.util.WeakHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -41,7 +43,19 @@ public class DynamicSynonymTokenFilterFactory extends
 
 	public static ESLogger logger = Loggers.getLogger("dynamic-synonym");
 
-	private ScheduledExecutorService pool;
+	/**
+     * 静态的id生成器
+     */
+    private static final AtomicInteger id = new AtomicInteger(1);
+    private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(1,
+            new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread thread = new Thread(r);
+                    thread.setName("monitor-synonym-Thread-" + id.getAndAdd(1));
+                    return thread;
+                }
+            });
 
 	private volatile ScheduledFuture<?> scheduledFuture;
 
@@ -77,8 +91,6 @@ public class DynamicSynonymTokenFilterFactory extends
 		this.ignoreCase = settings.getAsBoolean("ignore_case", false);
 		this.expand = settings.getAsBoolean("expand", true);
 		this.format = settings.get("format", "");
-
-		pool = Executors.newScheduledThreadPool(1);
 
 		String tokenizerName = settings.get("tokenizer", "whitespace");
 		TokenizerFactoryFactory tokenizerFactoryFactory = tokenizerFactories


### PR DESCRIPTION
DynamicSynonymTokenFilterFactory类中调度线程池[pool](https://github.com/bells/elasticsearch-analysis-dynamic-synonym/blob/master/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java)
为什么这个变量不是static 呢，我观察过同义词的初始化，每一个索引都会初始化一次，从监控中看到生成了多个对象。pool是线程池同时是检测更新的，一般频率会很低，并且这是针对同一个文件的更新，我感觉只需要一个池对象就能满足了，不知道你没有设置为静态是出于什么情况考虑的呢？ 另外，感谢查阅。
