### PR TITLE
Add Java security policy and refactor code with lambdas

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -11,6 +11,11 @@
             <outputDirectory>elasticsearch</outputDirectory>
             <filtered>true</filtered>
         </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/plugin-security.policy</source>
+            <outputDirectory>elasticsearch</outputDirectory>
+            <filtered>true</filtered>
+        </file>
     </files>
     <dependencySets>
         <dependencySet>

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/DynamicSynonymPlugin.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/DynamicSynonymPlugin.java
@@ -82,7 +82,7 @@ public class DynamicSynonymPlugin extends Plugin implements AnalysisPlugin {
 
         private AnalysisRegistry analysisRegistry;
 
-        public AnalysisRegistry getAnalysisRegistry() {
+        AnalysisRegistry getAnalysisRegistry() {
             return analysisRegistry;
         }
 

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -6,9 +6,7 @@ package com.bellszhu.elasticsearch.plugin.synonym.analysis;
 import org.apache.commons.codec.Charsets;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.synonym.SolrSynonymParser;
 import org.apache.lucene.analysis.synonym.SynonymMap;
-import org.apache.lucene.analysis.synonym.WordnetSynonymParser;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.env.Environment;
@@ -22,7 +20,7 @@ import java.nio.file.Path;
  */
 public class LocalSynonymFile implements SynonymFile {
 
-    public static Logger logger = ESLoggerFactory.getLogger("dynamic-synonym");
+    private static Logger logger = ESLoggerFactory.getLogger("dynamic-synonym");
 
     private String format;
 
@@ -41,8 +39,8 @@ public class LocalSynonymFile implements SynonymFile {
 
     private long lastModified;
 
-    public LocalSynonymFile(Environment env, Analyzer analyzer, boolean expand,
-                            String format, String location) {
+    LocalSynonymFile(Environment env, Analyzer analyzer, boolean expand,
+                     String format, String location) {
         this.analyzer = analyzer;
         this.expand = expand;
         this.format = format;
@@ -58,14 +56,7 @@ public class LocalSynonymFile implements SynonymFile {
         try {
             logger.info("start reload local synonym from {}.", location);
             Reader rulesReader = getReader();
-            SynonymMap.Builder parser = null;
-            if ("wordnet".equalsIgnoreCase(format)) {
-                parser = new WordnetSynonymParser(true, expand, analyzer);
-                ((WordnetSynonymParser) parser).parse(rulesReader);
-            } else {
-                parser = new SolrSynonymParser(true, expand, analyzer);
-                ((SolrSynonymParser) parser).parse(rulesReader);
-            }
+            SynonymMap.Builder parser = RemoteSynonymFile.getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();
         } catch (Exception e) {
             logger.error("reload local synonym {} error!", e, location);

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/SynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/SynonymFile.java
@@ -12,10 +12,10 @@ import java.io.Reader;
  */
 public interface SynonymFile {
 
-    public SynonymMap reloadSynonymMap();
+    SynonymMap reloadSynonymMap();
 
-    public boolean isNeedReloadSynonymMap();
+    boolean isNeedReloadSynonymMap();
 
-    public Reader getReader();
+    Reader getReader();
 
 }

--- a/src/main/resources/plugin-security.policy
+++ b/src/main/resources/plugin-security.policy
@@ -1,0 +1,3 @@
+grant {
+  permission java.net.SocketPermission "*", "connect,resolve";
+};


### PR DESCRIPTION
Because the Java Security Manager blocks remote call there was the need to add the wrappers and permissions to http calls. I also refactored the code a bit to be cleaner and added lambda's where possible because Java 8 is the supported and recommended version for Elastic 6.x