### PR TITLE
tolerate having no synonyms without failing the query

### DIFF
--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
@@ -111,12 +111,15 @@ public class DynamicSynonymTokenFilterFactory extends
 
     @Override
     public TokenStream create(TokenStream tokenStream) {
-        DynamicSynonymFilter dynamicSynonymFilter = new DynamicSynonymFilter(
-                tokenStream, synonymMap, ignoreCase);
+        // fst is null means no synonyms
+        if (synonymMap == null || synonymMap.fst == null) {
+            return tokenStream;
+        }
+
+        DynamicSynonymFilter dynamicSynonymFilter = new DynamicSynonymFilter(tokenStream, synonymMap, ignoreCase);
         dynamicSynonymFilters.put(dynamicSynonymFilter, 1);
 
-        // fst is null means no synonyms
-        return synonymMap.fst == null ? tokenStream : dynamicSynonymFilter;
+        return dynamicSynonymFilter;
     }
 
     public class Monitor implements Runnable {


### PR DESCRIPTION
If `synonymMap.fst` is null, then the `new DynamicSynonymFilter(...)` constructor will throw an `IllegalArgumentException`.  So we avoid even constructing the filter in the first place if we know we have no synonyms. 

Example stack trace when no synonyms:
```
"Caused by: java.lang.IllegalArgumentException: fst must be non-null",
"at com.bellszhu.elasticsearch.plugin.synonym.analysis.DynamicSynonymFilter.update(DynamicSynonymFilter.java:509) ~[?:?]",
"at com.bellszhu.elasticsearch.plugin.synonym.analysis.DynamicSynonymFilter.<init>(DynamicSynonymFilter.java:169) ~[?:?]",
"at com.bellszhu.elasticsearch.plugin.synonym.analysis.DynamicSynonymTokenFilterFactory.create(DynamicSynonymTokenFilterFactory.java:114) ~[?:?]",```