### PR TITLE
Fix#54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <elasticsearch.version>${project.version}</elasticsearch.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>12</maven.compiler.target>
         <elasticsearch.plugin.name>analysis-dynamic-synonym</elasticsearch.plugin.name>
         <elasticsearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml
         </elasticsearch.assembly.descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <elasticsearch.version>${project.version}</elasticsearch.version>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <elasticsearch.plugin.name>analysis-dynamic-synonym</elasticsearch.plugin.name>
         <elasticsearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml
         </elasticsearch.assembly.descriptor>
@@ -61,9 +61,21 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.7</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codelibs</groupId>
+            <artifactId>elasticsearch-cluster-runner</artifactId>
+            <version>${project.version}.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -63,7 +63,7 @@ public class LocalSynonymFile implements SynonymFile {
             SynonymMap.Builder parser = RemoteSynonymFile.getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();
         } catch (Exception e) {
-            logger.error("reload local synonym {} error!", e, location);
+            logger.error("reload local synonym {} error!", location, e);
             throw new IllegalArgumentException(
                     "could not reload local synonyms file to build synonyms", e);
         }
@@ -81,7 +81,7 @@ public class LocalSynonymFile implements SynonymFile {
             }
             return new StringReader(sb.toString());
         } catch (IOException e) {
-            logger.error("get local synonym reader {} error!", e, location);
+            logger.error("get local synonym reader {} error!", location, e);
             throw new IllegalArgumentException(
                     "IOException while reading local synonyms file", e);
         }
@@ -97,8 +97,7 @@ public class LocalSynonymFile implements SynonymFile {
                 return true;
             }
         } catch (Exception e) {
-            logger.error("check need reload local synonym {} error!", e,
-                    location);
+            logger.error("check need reload local synonym {} error!", location, e);
         }
 
         return false;

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -93,8 +93,10 @@ public class LocalSynonymFile implements SynonymFile {
             return new StringReader(sb.toString());
         } catch (IOException e) {
             logger.error("get local synonym reader {} error!", location, e);
-            throw new IllegalArgumentException(
-                    "IOException while reading local synonyms file", e);
+//            throw new IllegalArgumentException(
+//                    "IOException while reading local synonyms file", e);
+            // Fix #54 Returns blank if synonym file has be deleted.
+            return new StringReader("");
         }
     }
 

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -73,7 +73,7 @@ public class LocalSynonymFile implements SynonymFile {
     public Reader getReader() {
         try (BufferedReader br = new BufferedReader(new InputStreamReader(
                 synonymFilePath.toUri().toURL().openStream(), Charsets.UTF_8))) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             String line;
             while ((line = br.readLine()) != null) {
                 logger.info("reload local synonym: {}", line);

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -145,7 +145,7 @@ public class RemoteSynonymFile implements SynonymFile {
 
                 br = new BufferedReader(new InputStreamReader(response
                         .getEntity().getContent(), charset));
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 String line;
                 while ((line = br.readLine()) != null) {
                     logger.info("reload remote synonym: {}", line);

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -3,12 +3,6 @@
  */
 package com.bellszhu.elasticsearch.plugin.synonym.analysis;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HeaderIterator;
-import org.apache.http.HttpEntity;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -16,7 +10,6 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.params.HttpParams;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -33,7 +26,6 @@ import java.io.StringReader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.ParseException;
-import java.util.Locale;
 
 /**
  * @author bellszhu

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -92,7 +92,7 @@ public class RemoteSynonymFile implements SynonymFile {
             parser = getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();
         } catch (Exception e) {
-            logger.error("reload remote synonym {} error!", e, location);
+            logger.error("reload remote synonym {} error!", location, e);
             throw new IllegalArgumentException(
                     "could not reload remote synonyms file to build synonyms",
                     e);
@@ -112,7 +112,7 @@ public class RemoteSynonymFile implements SynonymFile {
             try {
                 return httpclient.execute(httpUriRequest);
             } catch (IOException e) {
-                logger.error("Unable to execute HTTP request: {}", e);
+                logger.error("Unable to execute HTTP request.", e);
             }
             return null;
         });
@@ -155,7 +155,7 @@ public class RemoteSynonymFile implements SynonymFile {
                 reader = new StringReader(sb.toString());
             }
         } catch (Exception e) {
-            logger.error("get remote synonym reader {} error!", e, location);
+            logger.error("get remote synonym reader {} error!", location, e);
             throw new IllegalArgumentException(
                     "Exception while reading remote synonyms file", e);
         } finally {

--- a/src/test/java/com.bellszhu.elasticsearch.plugin/DynamicSynonymPluginTest.java
+++ b/src/test/java/com.bellszhu.elasticsearch.plugin/DynamicSynonymPluginTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2019, guanquan.wang@yandex.com All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bellszhu.elasticsearch.plugin;
+
+import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner.newConfigs;
+
+/**
+ * Create by guanquan.wang at 2019-09-18 16:55
+ */
+public class DynamicSynonymPluginTest {
+    private ElasticsearchClusterRunner runner;
+
+    @Before
+    public void setUp() {
+        // create runner instance
+        runner = new ElasticsearchClusterRunner();
+        // create ES nodes
+        runner.build(newConfigs()
+                .numOfNode(1) // Create a test node, default number of node is 3.
+                .pluginTypes("com.bellszhu.elasticsearch.plugin.DynamicSynonymPlugin")
+        );
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        // close runner
+        runner.close();
+        // delete all files
+        runner.clean();
+    }
+
+    private void createIndexWithLocalSynonym(String indexName, String localPath) {
+        final String indexSettings = "{\n" +
+            "  \"index\":{\n" +
+            "    \"analysis\":{\n" +
+            "      \"filter\":{\n" +
+            "        \"local_synonym\": {\n" +
+            "            \"type\": \"dynamic_synonym\",\n" +
+            "            \"synonyms_path\": \"" + localPath + "\"," +
+            "            \"interval\": \"10\"\n" +
+            "        }"+
+            "      },\n" +
+            "      \"char_filter\":{\n" +
+            "        \"my_char_filter\":{\n" +
+            "          \"pattern\":\"[- /]\",\n" +
+            "          \"type\":\"pattern_replace\",\n" +
+            "          \"replacement\":\"\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"analyzer\":{\n" +
+            "        \"synonym_analyzer\":{\n" +
+            "          \"filter\":[\n" +
+            "            \"lowercase\",\n" +
+            "            \"asciifolding\",\n" +
+            "            \"local_synonym\"\n" +
+            "          ],\n" +
+            "          \"type\":\"custom\",\n" +
+            "          \"tokenizer\":\"keyword\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        runner.createIndex(indexName, Settings.builder().loadFromSource(indexSettings, XContentType.JSON).build());
+        // wait for yellow status
+        runner.ensureYellow();
+    }
+
+    private void createIndexWithRemoteSynonym(String indexName) {
+        final String indexSettings = "{\n" +
+            "  \"index\":{\n" +
+            "    \"analysis\":{\n" +
+            "      \"filter\":{\n" +
+            "        \"remote_synonym\": {\n" +
+            "            \"type\": \"dynamic_synonym\",\n" +
+            "            \"synonyms_path\": \"http://localhost:8080/synonym\"" +
+            "        }"+
+            "      },\n" +
+            "      \"char_filter\":{\n" +
+            "        \"my_char_filter\":{\n" +
+            "          \"pattern\":\"[- /]\",\n" +
+            "          \"type\":\"pattern_replace\",\n" +
+            "          \"replacement\":\"\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"analyzer\":{\n" +
+            "        \"synonym_analyzer\":{\n" +
+            "          \"filter\":[\n" +
+            "            \"lowercase\",\n" +
+            "            \"asciifolding\",\n" +
+            "            \"remote_synonym\"\n" +
+            "          ],\n" +
+            "          \"type\":\"custom\",\n" +
+            "          \"tokenizer\":\"keyword\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        runner.createIndex(indexName, Settings.builder().loadFromSource(indexSettings, XContentType.JSON).build());
+        // wait for yellow status
+        runner.ensureYellow();
+    }
+
+    private synchronized void analyzer(String indexName) throws InterruptedException {
+        AnalyzeAction.Request analyzeRequest = new AnalyzeAction.Request(indexName);
+        analyzeRequest.text("肯德基");
+        analyzeRequest.analyzer("synonym_analyzer");
+        ActionFuture<AnalyzeAction.Response> actionFuture = runner.admin().indices().analyze(analyzeRequest);
+        AnalyzeAction.Response response = actionFuture.actionGet(10L, TimeUnit.SECONDS);
+        List<AnalyzeAction.AnalyzeToken> tokens = response.getTokens();
+        for (AnalyzeAction.AnalyzeToken token : tokens) {
+            System.out.println(token.getTerm() + " => " + token.getType());
+        }
+
+        /*
+        Wait 2 minute to modify the synonym file and run again.
+         */
+        wait(1000 * 120);
+
+        analyzeRequest.text("肯德基");
+        analyzeRequest.analyzer("synonym_analyzer");
+        actionFuture = runner.admin().indices().analyze(analyzeRequest);
+        response = actionFuture.actionGet(10L, TimeUnit.SECONDS);
+        tokens = response.getTokens();
+        for (AnalyzeAction.AnalyzeToken token : tokens) {
+            System.out.println(token.getTerm() + " => " + token.getType());
+        }
+
+        analyzeRequest.text("america");
+        analyzeRequest.analyzer("synonym_analyzer");
+        actionFuture = runner.admin().indices().analyze(analyzeRequest);
+        response = actionFuture.actionGet(10L, TimeUnit.SECONDS);
+        tokens = response.getTokens();
+        for (AnalyzeAction.AnalyzeToken token : tokens) {
+            System.out.println(token.getTerm() + " => " + token.getType());
+        }
+    }
+
+    @Test
+    public void testLocalAbsolute() throws InterruptedException {
+        String index = "test_local_absolute";
+        String absolutePath = "target/test-classes/synonym.txt";
+        // create an index
+        createIndexWithLocalSynonym(index, absolutePath);
+
+        analyzer(index);
+    }
+
+    @Test
+    public void testLocal() throws InterruptedException {
+        String index = "test_local_relative";
+        String absolutePath = "synonym.txt";
+        // create an index
+        createIndexWithLocalSynonym(index, absolutePath);
+
+        analyzer(index);
+    }
+
+    @Test
+    public void testRemote() throws InterruptedException {
+        String index = "test_remote";
+        // create an index
+        createIndexWithRemoteSynonym(index);
+
+        analyzer(index);
+    }
+}

--- a/src/test/resources/synonym.txt
+++ b/src/test/resources/synonym.txt
@@ -1,0 +1,2 @@
+金拱门,肯德基,KFC
+america, unitied states, meiguo


### PR DESCRIPTION
1. 修改请求远程/本地文件失败后，抛异常导致Timer会停止刷新（远程服务器停机升级或网络抖动）
2. 增加Junit单元测试
3. 本地同义词文件增加绝对路径和相对路径支持（相对于插件当前位置）
4. 修改部分日志参数错误