### PR TITLE
Explicitly close for ClosableHttpResponse method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bellszhu.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-dynamic-synonym</artifactId>
-    <version>7.15.0</version>
+    <version>7.15.2</version>
     <packaging>jar</packaging>
     <name>elasticsearch-dynamic-synonym</name>
     <description>Analysis-plugin for synonym</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bellszhu.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-dynamic-synonym</artifactId>
-    <version>7.4.0</version>
+    <version>7.10.0</version>
     <packaging>jar</packaging>
     <name>elasticsearch-dynamic-synonym</name>
     <description>Analysis-plugin for synonym</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bellszhu.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-dynamic-synonym</artifactId>
-    <version>7.16.2</version>
+    <version>7.16.3</version>
     <packaging>jar</packaging>
     <name>elasticsearch-dynamic-synonym</name>
     <description>Analysis-plugin for synonym</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bellszhu.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-dynamic-synonym</artifactId>
-    <version>7.3.1</version>
+    <version>7.4.0</version>
     <packaging>jar</packaging>
     <name>elasticsearch-dynamic-synonym</name>
     <description>Analysis-plugin for synonym</description>
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <elasticsearch.version>${project.version}</elasticsearch.version>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <elasticsearch.plugin.name>analysis-dynamic-synonym</elasticsearch.plugin.name>
         <elasticsearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml
         </elasticsearch.assembly.descriptor>

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
@@ -1,20 +1,15 @@
 package com.bellszhu.elasticsearch.plugin.synonym.analysis;
 
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.core.LowerCaseFilter;
-import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
-import org.elasticsearch.index.analysis.Analysis;
 import org.elasticsearch.index.analysis.AnalysisMode;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
@@ -22,6 +17,7 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Executors;
@@ -29,174 +25,184 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import java.util.List;
 import java.util.function.Function;
 
 /**
  * @author bellszhu
  */
 public class DynamicSynonymTokenFilterFactory extends
-        AbstractTokenFilterFactory {
+		AbstractTokenFilterFactory {
 
-    private static final DeprecationLogger DEPRECATION_LOGGER
-            = new DeprecationLogger(LogManager.getLogger(DynamicSynonymTokenFilterFactory.class));
+	private static final DeprecationLogger DEPRECATION_LOGGER
+			= new DeprecationLogger(LogManager.getLogger(DynamicSynonymTokenFilterFactory.class));
 
-    /**
-     * Static id generator
-     */
-    private static final AtomicInteger id = new AtomicInteger(1);
-    private static Logger logger = LogManager.getLogger("dynamic-synonym");
-    private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(1, r -> {
-        Thread thread = new Thread(r);
-        thread.setName("monitor-synonym-Thread-" + id.getAndAdd(1));
-        return thread;
-    });
-    private final String location;
-    private final boolean expand;
-    private final boolean lenient;
-    private final String format;
-    private final int interval;
-    private volatile ScheduledFuture<?> scheduledFuture;
-    private SynonymMap synonymMap;
-    private Map<DynamicSynonymFilter, Integer> dynamicSynonymFilters = new WeakHashMap<>();
-    protected final Environment environment;
-    protected final AnalysisMode analysisMode;
+	/**
+	 * Static id generator
+	 */
+	private static final AtomicInteger id = new AtomicInteger(1);
+	private static Logger logger = LogManager.getLogger("dynamic-synonym");
+	private static ScheduledExecutorService pool = Executors.newScheduledThreadPool(1, r -> {
+		Thread thread = new Thread(r);
+		thread.setName("monitor-synonym-Thread-" + id.getAndAdd(1));
+		return thread;
+	});
+	private final String location;
+	private final boolean expand;
+	private final boolean lenient;
+	private final String format;
+	private final int interval;
+	private volatile ScheduledFuture<?> scheduledFuture;
+	private SynonymMap synonymMap;
+	private Map<DynamicSynonymFilter, Integer> dynamicSynonymFilters = new WeakHashMap<>();
+	protected final Environment environment;
+	protected final AnalysisMode analysisMode;
 
-    public DynamicSynonymTokenFilterFactory(
-            IndexSettings indexSettings,
-            Environment env,
-            String name,
-            Settings settings
-    ) throws IOException {
+	public DynamicSynonymTokenFilterFactory(
+			IndexSettings indexSettings,
+			Environment env,
+			String name,
+			Settings settings
+	) throws IOException {
 
-        super(indexSettings, name, settings);
+		super(indexSettings, name, settings);
 
-        this.location = settings.get("synonyms_path");
-        if (this.location == null) {
-            throw new IllegalArgumentException(
-                    "dynamic synonym requires `synonyms_path` to be configured");
-        }
+		this.location = settings.get("synonyms_path");
+		if (this.location == null) {
+			throw new IllegalArgumentException(
+					"dynamic synonym requires `synonyms_path` to be configured");
+		}
 
-        this.interval = settings.getAsInt("interval", 60);
-        if (settings.get("ignore_case") != null) {
-            DEPRECATION_LOGGER.deprecated(
-                "The ignore_case option on the synonym_graph filter is deprecated. " +
-                    "Instead, insert a lowercase filter in the filter chain before the synonym_graph filter.");
-        }
-        this.expand = settings.getAsBoolean("expand", true);
-        this.lenient = settings.getAsBoolean("lenient", false);
-        this.format = settings.get("format", "");
-        boolean updateable = settings.getAsBoolean("updateable", false);
-        this.analysisMode = updateable ? AnalysisMode.SEARCH_TIME : AnalysisMode.ALL;
-        this.environment = env;
-    }
+		this.interval = settings.getAsInt("interval", 60);
+		if (settings.get("ignore_case") != null) {
+			DEPRECATION_LOGGER.deprecated(
+					"The ignore_case option on the synonym_graph filter is deprecated. " +
+							"Instead, insert a lowercase filter in the filter chain before the synonym_graph filter.");
+		}
+		this.expand = settings.getAsBoolean("expand", true);
+		this.lenient = settings.getAsBoolean("lenient", false);
+		this.format = settings.get("format", "");
+		boolean updateable = settings.getAsBoolean("updateable", false);
+		this.analysisMode = updateable ? AnalysisMode.SEARCH_TIME : AnalysisMode.ALL;
+		this.environment = env;
+	}
 
-    @Override
-    public AnalysisMode getAnalysisMode() {
-        return this.analysisMode;
-    }
+	@Override
+	public AnalysisMode getAnalysisMode() {
+		return this.analysisMode;
+	}
 
+	@Override
+	public TokenStream create(TokenStream tokenStream) {
+		throw new IllegalStateException(
+				"Call getChainAwareTokenFilterFactory to specialize this factory for an analysis chain first");
+	}
 
-    @Override
-    public TokenStream create(TokenStream tokenStream) {
-        throw new IllegalStateException("Call getChainAwareTokenFilterFactory to specialize this factory for an analysis chain first");
-    }
+	public TokenFilterFactory getChainAwareTokenFilterFactory(
+			TokenizerFactory tokenizer, List<CharFilterFactory> charFilters,
+			List<TokenFilterFactory> previousTokenFilters,
+			Function<String, TokenFilterFactory> allFilters
+	) {
+		final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters);
+		synonymMap = buildSynonyms(analyzer);
+		final String name = name();
+		return new TokenFilterFactory() {
 
-    public TokenFilterFactory getChainAwareTokenFilterFactory(TokenizerFactory tokenizer, List<CharFilterFactory> charFilters,
-                                                              List<TokenFilterFactory> previousTokenFilters,
-                                                              Function<String, TokenFilterFactory> allFilters) {
-        final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters);
-        synonymMap = buildSynonyms(analyzer);
-        final String name = name();
-        return new TokenFilterFactory() {
-            @Override
-            public String name() {
-                return name;
-            }
+			@Override
+			public String name() {
+				return name;
+			}
 
-            @Override
-            public TokenStream create(TokenStream tokenStream) {
-                // fst is null means no synonyms
-                if (synonymMap.fst == null) {
-                    return tokenStream;
-                }
-                DynamicSynonymFilter dynamicSynonymFilter = new DynamicSynonymFilter(tokenStream, synonymMap, false);
-                dynamicSynonymFilters.put(dynamicSynonymFilter, 1);
+			@Override
+			public TokenStream create(TokenStream tokenStream) {
+				// fst is null means no synonyms
+				if (synonymMap.fst == null) {
+					return tokenStream;
+				}
+				DynamicSynonymFilter dynamicSynonymFilter = new DynamicSynonymFilter(tokenStream, synonymMap, false);
+				dynamicSynonymFilters.put(dynamicSynonymFilter, 1);
 
-                return dynamicSynonymFilter;
-            }
+				return dynamicSynonymFilter;
+			}
 
-            @Override
-            public TokenFilterFactory getSynonymFilter() {
-                // In order to allow chained synonym filters, we return IDENTITY here to
-                // ensure that synonyms don't get applied to the synonym map itself,
-                // which doesn't support stacked input tokens
-                return IDENTITY_FILTER;
-            }
+			@Override
+			public TokenFilterFactory getSynonymFilter() {
+				// In order to allow chained synonym filters, we return IDENTITY here to
+				// ensure that synonyms don't get applied to the synonym map itself,
+				// which doesn't support stacked input tokens
+				return IDENTITY_FILTER;
+			}
 
-            @Override
-            public AnalysisMode getAnalysisMode() {
-                return analysisMode;
-            }
-        };
-    }
+			@Override
+			public AnalysisMode getAnalysisMode() {
+				return analysisMode;
+			}
+		};
+	}
 
-    Analyzer buildSynonymAnalyzer(TokenizerFactory tokenizer, List<CharFilterFactory> charFilters,
-                                  List<TokenFilterFactory> tokenFilters, Function<String, TokenFilterFactory> allFilters) {
-        return new CustomAnalyzer("dynamic_synonym", tokenizer, charFilters.toArray(new CharFilterFactory[0]),
-            tokenFilters.stream()
-                .map(TokenFilterFactory::getSynonymFilter)
-                .toArray(TokenFilterFactory[]::new));
-    }
+	private Analyzer buildSynonymAnalyzer(
+			TokenizerFactory tokenizer, List<CharFilterFactory> charFilters,
+			List<TokenFilterFactory> tokenFilters, Function<String, TokenFilterFactory> allFilters
+	) {
+		return new CustomAnalyzer(tokenizer, charFilters.toArray(new CharFilterFactory[0]),
+				tokenFilters.stream()
+						.map(TokenFilterFactory::getSynonymFilter)
+						.toArray(TokenFilterFactory[]::new));
+	}
 
-    SynonymMap buildSynonyms(Analyzer analyzer) {
-        try {
-            return getSynonymFile(analyzer).reloadSynonymMap();
-        } catch (Exception e) {
-            throw new IllegalArgumentException("failed to build synonyms", e);
-        }
-    }
+	private SynonymMap buildSynonyms(Analyzer analyzer) {
+		try {
+			return getSynonymFile(analyzer).reloadSynonymMap();
+		} catch (Exception e) {
+			throw new IllegalArgumentException("failed to build synonyms", e);
+		}
+	}
 
-    SynonymFile getSynonymFile(Analyzer analyzer) {
-        try {
-            SynonymFile synonymFile;
-            if (location.startsWith("http://") || location.startsWith("https://")) {
-                synonymFile = new RemoteSynonymFile(environment, analyzer, expand, format,
-                        location);
-            } else {
-                synonymFile = new LocalSynonymFile(environment, analyzer, expand, format,
-                        location);
-            }
-            if (scheduledFuture == null) {
-                scheduledFuture = pool.scheduleAtFixedRate(new Monitor(synonymFile),
-                                interval, interval, TimeUnit.SECONDS);
-            }
-            return synonymFile;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("failed to get synonyms : " + location, e);
-        }
-    }
+	private SynonymFile getSynonymFile(Analyzer analyzer) {
+		try {
+			SynonymFile synonymFile;
+			if (location.startsWith("http://") || location.startsWith("https://")) {
+				synonymFile = new RemoteSynonymFile(environment, analyzer, expand, format,
+						location
+				);
+			} else {
+				synonymFile = new LocalSynonymFile(environment, analyzer, expand, format,
+						location
+				);
+			}
+			if (scheduledFuture == null) {
+				scheduledFuture = pool.scheduleAtFixedRate(new Monitor(synonymFile),
+						interval, interval, TimeUnit.SECONDS
+				);
+			}
+			return synonymFile;
+		} catch (Exception e) {
+			throw new IllegalArgumentException("failed to get synonyms : " + location, e);
+		}
+	}
 
-    public class Monitor implements Runnable {
+	public class Monitor implements Runnable {
 
-        private SynonymFile synonymFile;
+		private SynonymFile synonymFile;
 
-        Monitor(SynonymFile synonymFile) {
-            this.synonymFile = synonymFile;
-        }
+		Monitor(SynonymFile synonymFile) {
+			this.synonymFile = synonymFile;
+		}
 
-        @Override
-        public void run() {
-            if (synonymFile.isNeedReloadSynonymMap()) {
-                synonymMap = synonymFile.reloadSynonymMap();
-                for (DynamicSynonymFilter dynamicSynonymFilter : dynamicSynonymFilters
-                        .keySet()) {
-                    dynamicSynonymFilter.update(synonymMap);
-                    logger.info("success reload synonym");
-                }
-            }
-        }
-    }
+		@Override
+		public void run() {
+			try {
+				if (synonymFile.isNeedReloadSynonymMap()) {
+					synonymMap = synonymFile.reloadSynonymMap();
+					for (DynamicSynonymFilter dynamicSynonymFilter : dynamicSynonymFilters
+							.keySet()) {
+						dynamicSynonymFilter.update(synonymMap);
+						logger.info("success reload synonym");
+					}
+				}
+			} catch (Exception e) {
+				logger.error("failed to reload the synonyms, keep using previous synonymMap.");
+			}
+		}
+	}
 
 }

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
@@ -202,7 +202,7 @@ public class DynamicSynonymTokenFilterFactory extends
                 synonymMap = synonymFile.reloadSynonymMap();
                 for (AbsSynonymFilter dynamicSynonymFilter : dynamicSynonymFilters.keySet()) {
                     dynamicSynonymFilter.update(synonymMap);
-                    logger.info("success reload synonym");
+                    logger.debug("success reload synonym");
                 }
             }
         }

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/DynamicSynonymTokenFilterFactory.java
@@ -35,8 +35,6 @@ import org.elasticsearch.index.analysis.TokenizerFactory;
 public class DynamicSynonymTokenFilterFactory extends
         AbstractTokenFilterFactory {
 
-//    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(
-//            DynamicSynonymTokenFilterFactory.class);
     private static final Logger logger = LogManager.getLogger("dynamic-synonym");
 
     /**
@@ -74,12 +72,6 @@ public class DynamicSynonymTokenFilterFactory extends
                     "dynamic synonym requires `synonyms_path` to be configured");
         }
         if (settings.get("ignore_case") != null) {
-//            DEPRECATION_LOGGER.deprecate(
-//                    DeprecationCategory.ANALYSIS,
-//                    "dynamic synonym ignore_case",
-//                    "The ignore_case option on the synonym_graph filter is deprecated. " +
-//                            "Instead, insert a lowercase filter in the filter chain before the synonym_graph filter."
-//            );
         }
 
         this.interval = settings.getAsInt("interval", 60);

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -61,7 +61,7 @@ public class LocalSynonymFile implements SynonymFile {
     @Override
     public SynonymMap reloadSynonymMap() {
         try {
-            logger.info("start reload local synonym from {}.", synonymFilePath);
+            logger.debug("start reload local synonym from {}.", synonymFilePath);
             Reader rulesReader = getReader();
             SynonymMap.Builder parser = RemoteSynonymFile.getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -61,7 +61,6 @@ public class LocalSynonymFile implements SynonymFile {
     @Override
     public SynonymMap reloadSynonymMap() {
         try {
-            logger.info("start reload local synonym from {}.", synonymFilePath);
             Reader rulesReader = getReader();
             SynonymMap.Builder parser = RemoteSynonymFile.getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/LocalSynonymFile.java
@@ -61,6 +61,7 @@ public class LocalSynonymFile implements SynonymFile {
     @Override
     public SynonymMap reloadSynonymMap() {
         try {
+            logger.info("start reload local synonym from {}.", synonymFilePath);
             Reader rulesReader = getReader();
             SynonymMap.Builder parser = RemoteSynonymFile.getSynonymParser(rulesReader, format, expand, analyzer);
             return parser.build();

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -85,7 +85,7 @@ public class RemoteSynonymFile implements SynonymFile {
     public SynonymMap reloadSynonymMap() {
         Reader rulesReader = null;
         try {
-            logger.info("start reload remote synonym from {}.", location);
+            logger.debug("start reload remote synonym from {}.", location);
             rulesReader = getReader();
             SynonymMap.Builder parser;
 
@@ -148,7 +148,7 @@ public class RemoteSynonymFile implements SynonymFile {
                 StringBuilder sb = new StringBuilder();
                 String line;
                 while ((line = br.readLine()) != null) {
-                    logger.info("reload remote synonym: {}", line);
+                    logger.debug("reload remote synonym: {}", line);
                     sb.append(line)
                             .append(System.getProperty("line.separator"));
                 }

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -85,6 +85,7 @@ public class RemoteSynonymFile implements SynonymFile {
     public SynonymMap reloadSynonymMap() {
         Reader rulesReader = null;
         try {
+            logger.info("start reload remote synonym from {}.", location);
             rulesReader = getReader();
             SynonymMap.Builder parser;
 
@@ -147,6 +148,7 @@ public class RemoteSynonymFile implements SynonymFile {
                 StringBuilder sb = new StringBuilder();
                 String line;
                 while ((line = br.readLine()) != null) {
+                    logger.info("reload remote synonym: {}", line);
                     sb.append(line)
                             .append(System.getProperty("line.separator"));
                 }

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -85,7 +85,6 @@ public class RemoteSynonymFile implements SynonymFile {
     public SynonymMap reloadSynonymMap() {
         Reader rulesReader = null;
         try {
-            logger.info("start reload remote synonym from {}.", location);
             rulesReader = getReader();
             SynonymMap.Builder parser;
 
@@ -148,7 +147,6 @@ public class RemoteSynonymFile implements SynonymFile {
                 StringBuilder sb = new StringBuilder();
                 String line;
                 while ((line = br.readLine()) != null) {
-                    logger.info("reload remote synonym: {}", line);
                     sb.append(line)
                             .append(System.getProperty("line.separator"));
                 }

--- a/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
+++ b/src/main/java/com/bellszhu/elasticsearch/plugin/synonym/analysis/RemoteSynonymFile.java
@@ -132,7 +132,7 @@ public class RemoteSynonymFile implements SynonymFile {
                 .setConnectionRequestTimeout(10 * 1000)
                 .setConnectTimeout(10 * 1000).setSocketTimeout(60 * 1000)
                 .build();
-        CloseableHttpResponse response;
+        CloseableHttpResponse response = null;
         BufferedReader br = null;
         HttpGet get = new HttpGet(location);
         get.setConfig(rc);
@@ -172,6 +172,13 @@ public class RemoteSynonymFile implements SynonymFile {
                 }
             } catch (IOException e) {
                 logger.error("failed to close bufferedReader", e);
+            }
+            try {
+                if (response != null) {
+                    response.close();
+                }
+            } catch (IOException e) {
+                logger.error("failed to close http response", e);
             }
         }
         return reader;


### PR DESCRIPTION
Hereby a pull request to add an explicit close for ClosableHttpResponse method in the final clause of remoteSynonymFile.
We are seeing memory usage of our ES masters build up slowly over time when using this plugin and it would not hurt to close this connection just to be sure it is not creating leaks.